### PR TITLE
Add ProjectCard component and replace placeholders

### DIFF
--- a/src/components/ProjectCard.js
+++ b/src/components/ProjectCard.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Card } from 'antd';
+
+function ProjectCard({ title, description, link, linkLabel = 'View' }) {
+  return (
+    <Card title={title} hoverable>
+      <p>{description}</p>
+      {link && (
+        <a href={link} target="_blank" rel="noopener noreferrer">
+          {linkLabel}
+        </a>
+      )}
+    </Card>
+  );
+}
+
+export default ProjectCard;

--- a/src/views/my-projects.js
+++ b/src/views/my-projects.js
@@ -1,27 +1,47 @@
-import React ,{useState} from 'react';
-import ReactDOM from 'react-dom';
-import { Divider ,Timeline} from 'antd';
-
+import React from 'react';
+import { Divider, Row, Col } from 'antd';
+import ProjectCard from '../components/ProjectCard';
 
 function MyProject(props){
+  const projects = [
+    {
+      title: 'Learning the basics',
+      description: 'Practising fundamental programming concepts',
+      link: '#'
+    },
+    {
+      title: 'Web Development Full Stack',
+      description: 'Building a complete stack web application',
+      link: '#'
+    },
+    {
+      title: 'Android OS',
+      description: 'Creating small apps for Android OS',
+      link: '#'
+    }
+  ];
 
-return (
-  <>
-  <div className="site-layout-background" style={{ padding: 24, minHeight: 360 }}>
-            <Divider><h2>My Projects</h2></Divider>
-             <Divider  orientation="left" ><h2>Learning the basics</h2></Divider>
-             <Divider orientation="left" ><h2>Web Development Full Stack</h2></Divider>
-              <Divider orientation="left" ><h2>Android OS</h2></Divider>
-            </div>
-   <div className="site-layout-background" style={{ padding: 24, minHeight: 360 }}>
-            <Divider><h2>Goals</h2></Divider>
-
-            </div>
-  </>
+  return (
+    <>
+      <div className="site-layout-background" style={{ padding: 24, minHeight: 360 }}>
+        <Divider><h2>My Projects</h2></Divider>
+        <Row gutter={[16, 16]}>
+          {projects.map(project => (
+            <Col xs={24} sm={12} md={8} key={project.title}>
+              <ProjectCard
+                title={project.title}
+                description={project.description}
+                link={project.link}
+              />
+            </Col>
+          ))}
+        </Row>
+      </div>
+      <div className="site-layout-background" style={{ padding: 24, minHeight: 360 }}>
+        <Divider><h2>Goals</h2></Divider>
+      </div>
+    </>
   )
-
-
-
 }
 
-export default MyProject
+export default MyProject;


### PR DESCRIPTION
## Summary
- build a reusable `ProjectCard` wrapper around Ant Design `Card`
- show a grid of `ProjectCard`s in the My Projects view

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae859f8f08321b9b983386d8c8aed